### PR TITLE
Enforce 100% test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ site
 
 # Sensitive credentials
 *-credentials.yaml
+
+# Misc
+.DS_STORE

--- a/package.json
+++ b/package.json
@@ -54,6 +54,14 @@
   "jest": {
     "transformModules": [
       "@asyncapi/react-component"
-    ]
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    }
   }
 }


### PR DESCRIPTION
Let's attempt to get this to 100%.

Because:

1. It is open source, so more contributors. This safeguards bad commits or things we missed.
1. We do this early, so it's easier to maintain longer term.